### PR TITLE
[RHCLOUD-36096] add handler for quarkus-redis-cache extension

### DIFF
--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfig.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfig.java
@@ -8,6 +8,7 @@ import java.util.List;
 public class ClowderConfig {
 
     public DatabaseConfig database;
+    public InMemoryDb inMemoryDb;
     public List<EndpointConfig> endpoints;
     public List<PrivateEndpointConfig> privateEndpoints;
     public KafkaConfig kafka;

--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSourceFactory.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSourceFactory.java
@@ -1,18 +1,7 @@
 package com.redhat.cloud.common.clowder.configsource;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.redhat.cloud.common.clowder.configsource.handlers.ClowderPropertyHandler;
-import com.redhat.cloud.common.clowder.configsource.handlers.EndpointsClowderPropertyHandler;
-import com.redhat.cloud.common.clowder.configsource.handlers.KafkaBootstrapServersClowderPropertyHandler;
-import com.redhat.cloud.common.clowder.configsource.handlers.KafkaSecurityClowderPropertyHandler;
-import com.redhat.cloud.common.clowder.configsource.handlers.MicroprofileMessagingClowderPropertyHandler;
-import com.redhat.cloud.common.clowder.configsource.handlers.OptionalEndpointsClowderPropertyHandler;
-import com.redhat.cloud.common.clowder.configsource.handlers.OptionalPrivateEndpointsClowderPropertyHandler;
-import com.redhat.cloud.common.clowder.configsource.handlers.PrivateEndpointsClowderPropertyHandler;
-import com.redhat.cloud.common.clowder.configsource.handlers.QuarkusDataSourceClowderPropertyHandler;
-import com.redhat.cloud.common.clowder.configsource.handlers.QuarkusLogCloudWatchClowderPropertyHandler;
-import com.redhat.cloud.common.clowder.configsource.handlers.QuarkusUnleashClowderPropertyHandler;
-import com.redhat.cloud.common.clowder.configsource.handlers.WebPortClowderPropertyHandler;
+import com.redhat.cloud.common.clowder.configsource.handlers.*;
 import io.smallrye.config.ConfigSourceContext;
 import io.smallrye.config.ConfigSourceFactory;
 import io.smallrye.config.ConfigValue;
@@ -76,7 +65,8 @@ public class ClowderConfigSourceFactory implements ConfigSourceFactory {
                 new OptionalPrivateEndpointsClowderPropertyHandler(root),
                 new PrivateEndpointsClowderPropertyHandler(root),
                 new MicroprofileMessagingClowderPropertyHandler(root),
-                new QuarkusUnleashClowderPropertyHandler(root));
+                new QuarkusUnleashClowderPropertyHandler(root),
+                new QuarkusRedisClowderPropertyHandler(root));
     }
 
     private static List<ConfigSource> loadClowderConfigFromFile(ConfigSourceContext configSourceContext, File clowderConfigFile) {

--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/InMemoryDb.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/InMemoryDb.java
@@ -1,0 +1,12 @@
+package com.redhat.cloud.common.clowder.configsource;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class InMemoryDb {
+
+    public String hostname;
+    public Integer port;
+    public String username;
+    public String password;
+}

--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/QuarkusRedisClowderPropertyHandler.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/QuarkusRedisClowderPropertyHandler.java
@@ -1,0 +1,51 @@
+package com.redhat.cloud.common.clowder.configsource.handlers;
+
+import com.redhat.cloud.common.clowder.configsource.ClowderConfig;
+import com.redhat.cloud.common.clowder.configsource.ClowderConfigSource;
+
+public class QuarkusRedisClowderPropertyHandler extends ClowderPropertyHandler {
+    private static final String QUARKUS_REDIS = "quarkus.redis.";
+
+    public QuarkusRedisClowderPropertyHandler(ClowderConfig clowderConfig) {
+        super(clowderConfig);
+    }
+
+    @Override
+    public boolean handles(String property) {
+        return property.startsWith(QUARKUS_REDIS);
+    }
+
+    @Override
+    public String handle(String property, ClowderConfigSource configSource) {
+        if (clowderConfig.inMemoryDb == null) {
+            throw new IllegalStateException("No inMemoryDb section found");
+        }
+
+        String sub = property.substring(QUARKUS_REDIS.length());
+
+        return switch (sub) {
+            case "hosts" -> "redis://" + getURIAuthority();
+            case "password" ->
+                    clowderConfig.inMemoryDb.password; // Note: This value will be overriden by a password provided in `quarkus.redis.hosts`.
+            default ->
+                    configSource.getExistingValue(property); // fallback to fetching the value from application.properties
+        };
+    }
+
+    private String getURIAuthority() {
+        String hosts = clowderConfig.inMemoryDb.hostname;
+
+        if (clowderConfig.inMemoryDb.username != null && clowderConfig.inMemoryDb.password != null) {
+            hosts = clowderConfig.inMemoryDb.username + ":" + clowderConfig.inMemoryDb.password + "@" + hosts;
+        } else if (clowderConfig.inMemoryDb.password != null) {
+            hosts = ":" + clowderConfig.inMemoryDb.password + "@" + hosts;
+        } else if (clowderConfig.inMemoryDb.username != null) {
+            throw new IllegalStateException("In-memory DB password must be specified if username is provided");
+        }
+
+        if (clowderConfig.inMemoryDb.port != null) {
+            hosts += ":" + clowderConfig.inMemoryDb.port;
+        }
+        return hosts;
+    }
+}

--- a/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
+++ b/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
@@ -170,6 +170,32 @@ public class ConfigSourceTest {
     }
 
     @Test
+    void testInMemoryDb() {
+        String hosts = ccs.getValue("quarkus.redis.hosts");
+        assertEquals("redis://some.redis.host:6379", hosts);
+    }
+
+    @Test
+    void testInMemoryDbWithCredentials() {
+        ClowderConfigSource ccs2 = configSourceWithFile("/cdappconfig2.json", exposeKafkaSslConfigKeys);
+        String hosts = ccs2.getValue("quarkus.redis.hosts");
+        assertEquals("redis://dbuser:secret@some.redis.db:6379", hosts);
+
+        String password = ccs2.getValue("quarkus.redis.password");
+        assertEquals("secret", password);
+    }
+
+    /** Tests that a password must be provided if the username is specified. */
+    @Test
+    void testInMemoryDbWithMissingPassword() {
+        ClowderConfigSource ccs3 = configSourceWithFile("/cdappconfig3.json", exposeKafkaSslConfigKeys);
+        assertThrows(IllegalStateException.class, () -> ccs3.getValue("quarkus.redis.hosts"), "In-memory DB password must be specified if username is provided");
+
+        String password = ccs3.getValue("quarkus.redis.password");
+        assertNull(password);
+    }
+
+    @Test
     void testUnchangedProperty() {
         String value = ccs.getValue("quarkus.http.access-log.category");
         assertEquals("access_log", value);
@@ -264,6 +290,12 @@ public class ConfigSourceTest {
     void testNoDatabaseSection() {
         ClowderConfigSource source = configSourceWithFile("/cdappconfig3.json", exposeKafkaSslConfigKeys);
         assertThrows(IllegalStateException.class, () -> source.getValue("quarkus.datasource.username"));
+    }
+
+    @Test
+    void testNoInMemoryDbSection() {
+        ClowderConfigSource source = configSourceWithFile("/cdappconfig4.json", exposeKafkaSslConfigKeys);
+        assertThrows(IllegalStateException.class, () -> source.getValue("quarkus.redis.hosts"));
     }
 
     @Test

--- a/src/test/resources/cdappconfig.json
+++ b/src/test/resources/cdappconfig.json
@@ -9,6 +9,10 @@
     "sslMode": "require",
     "username": "aUser"
   },
+  "inMemoryDb": {
+    "hostname": "some.redis.host",
+    "port": 6379
+  },
   "endpoints": [
     {
       "app": "notifications",

--- a/src/test/resources/cdappconfig2.json
+++ b/src/test/resources/cdappconfig2.json
@@ -9,6 +9,12 @@
     "sslMode": "require",
     "username": "aUser"
   },
+  "inMemoryDb": {
+    "hostname": "some.redis.db",
+    "port": 6379,
+    "username": "dbuser",
+    "password": "secret"
+  },
   "endpoints": [
     {
       "app": "notifications",

--- a/src/test/resources/cdappconfig3.json
+++ b/src/test/resources/cdappconfig3.json
@@ -1,4 +1,9 @@
 {
+  "inMemoryDb": {
+    "hostname": "some.redis.db",
+    "port": 6379,
+    "username": "dbuser"
+  },
   "endpoints": [
     {
       "app": "notifications",


### PR DESCRIPTION
## Jira issue

https://issues.redhat.com/browse/RHCLOUD-36096

## Description

Adds a new `QuarkusRedisClowderPropertyHandler` to convert the configuration provided by the[`.inMemoryDb` object](https://redhatinsights.github.io/clowder/clowder/dev/providers/inmemorydb.html), to those used by the [quarkus-redis-client extension](https://quarkus.io/guides/redis-reference). Supports the `quarkus.redis.` prefix, setting properties `hosts` and `password`.

> [!IMPORTANT]
> The password will also be included in the`hosts` URI. My understanding of [the URI scheme](https://www.iana.org/assignments/uri-schemes/prov/redis) is that the password is required if a username is provided (although I've allowed ). Additionally, the [Vert.x client](https://github.com/vert-x3/vertx-redis-client/blob/0995a36f7ee23f40aa35381791400344c1821ad6/src/main/java/io/vertx/redis/client/impl/RedisConnectionManager.java#L249) will always attempt to extract the password from the URI first, and only uses the `password` property if this fails. Although this setup doesn't provide a scenario where the password won't be included in the URI, it maintains compatibility the best.

## Compatibility

No change to existing functionality.

## Testing

Added new test cases to handle in-memory databases with and without authentication. 